### PR TITLE
Add a section in the RFC template for performance considerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ that need to be addressed when creating an RFC:
 
 <Discussion of the work being proposed>
 
+### Performance Considerations
+
+Will this change affect performance of an existing feature, or a new feature that is performance sensitive?
+
+What are the performance goals of the change? N requsts per second? Better resource (CPU, IO, locks) usage? Better than X DB?
+
+Requires performance testing? yes/no. Which parts are affected. If yes, the Performance Team will need to be notified in advance.
+
 ### References
 
 <Links to existing projects or source code; external references>


### PR DESCRIPTION
I think most people were in agreement that having a section on performance in the RFC template was a good idea, so here it is.

No other sections were added that were suggested have been added. This is because of my own time constraints and not wanting a eng-wide review of the template to block this small improvement.

Also, the template should probably remain as light weight as possible to encourage everyone to use it.